### PR TITLE
fix issue with missing sample_main in sample plugin

### DIFF
--- a/src/examples/sample-plugin/sample/sample.c
+++ b/src/examples/sample-plugin/sample/sample.c
@@ -63,6 +63,8 @@ VLIB_PLUGIN_REGISTER () = {
 };
 /* *INDENT-ON* */
 
+sample_main_t sample_main;
+
 /**
  * @brief Enable/disable the macswap plugin. 
  *


### PR DESCRIPTION
Change-Id: Ia17511e3997cdcf1d0991e62e8e2d3fb8812d133
Signed-off-by: Damjan Marion <damarion@cisco.com>