### PR TITLE
pci_dev in dpdk/device/cli.c for RTE_SCHED_COLLECT_STATS

### DIFF
--- a/src/plugins/dpdk/device/cli.c
+++ b/src/plugins/dpdk/device/cli.c
@@ -1848,6 +1848,7 @@ show_dpdk_hqos_queue_stats (vlib_main_t * vm, unformat_input_t * input,
   dpdk_device_t *xd;
   uword *p = 0;
   struct rte_eth_dev_info dev_info;
+  struct rte_pci_device *pci_dev;
   dpdk_device_config_t *devconf = 0;
   u32 qindex;
   struct rte_sched_queue_stats stats;
@@ -1893,14 +1894,16 @@ show_dpdk_hqos_queue_stats (vlib_main_t * vm, unformat_input_t * input,
   xd = vec_elt_at_index (dm->devices, hw->dev_instance);
 
   rte_eth_dev_info_get (xd->port_id, &dev_info);
-  if (dev_info.pci_dev)
+  pci_dev = dpdk_get_pci_device (&dev_info);
+
+  if (pci_dev)
     {				/* bonded interface has no pci info */
       vlib_pci_addr_t pci_addr;
 
-      pci_addr.domain = dev_info.pci_dev->addr.domain;
-      pci_addr.bus = dev_info.pci_dev->addr.bus;
-      pci_addr.slot = dev_info.pci_dev->addr.devid;
-      pci_addr.function = dev_info.pci_dev->addr.function;
+      pci_addr.domain = pci_dev->addr.domain;
+      pci_addr.bus = pci_dev->addr.bus;
+      pci_addr.slot = pci_dev->addr.devid;
+      pci_addr.function = pci_dev->addr.function;
 
       p =
 	hash_get (dm->conf->device_config_index_by_pci_addr, pci_addr.as_u32);


### PR DESCRIPTION
when RTE_SCHED_COLLECT_STATS is defined,
pci_dev was still being used from dev_info.