### PR TITLE
vpp crashes when attempting to run in kubernetes Pod 

### DIFF
--- a/src/vnet/devices/virtio/vhost_user.c
+++ b/src/vnet/devices/virtio/vhost_user.c
@@ -1277,7 +1277,9 @@ vhost_user_exit (vlib_main_t * vm)
   vhost_user_main_t *vum = &vhost_user_main;
   vhost_user_intf_t *vui;
 
-  vlib_worker_thread_barrier_sync (vlib_get_main ());
+  if (vec_len (vlib_mains) > 1)
+    vlib_worker_thread_barrier_sync (vlib_get_main ());
+
   /* *INDENT-OFF* */
   pool_foreach (vui, vum->vhost_user_interfaces, {
       vhost_user_delete_if (vnm, vm, vui->sw_if_index);

--- a/src/vppinfra/pmalloc.c
+++ b/src/vppinfra/pmalloc.c
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <linux/mempolicy.h>
 #include <linux/memfd.h>
 
@@ -254,6 +255,7 @@ pmalloc_map_pages (clib_pmalloc_main_t * pm, clib_pmalloc_arena_t * a,
   int old_mpol = -1;
   long unsigned int mask[16] = { 0 };
   long unsigned int old_mask[16] = { 0 };
+  uword page_size = 1 << a->log2_subpage_sz;
   uword size = (uword) n_pages << pm->def_log2_page_sz;
 
   clib_error_free (pm->error);
@@ -324,6 +326,20 @@ pmalloc_map_pages (clib_pmalloc_main_t * pm, clib_pmalloc_arena_t * a,
 					  "fd %d numa %d flags 0x%x", n_pages,
 					  va, a->fd, numa_node, mmap_flags);
       goto error;
+    }
+
+  /* Check if huge page is not allocated,
+     wrong allocation will generate the SIGBUS */
+  for (int i = 0; i < n_pages; i++)
+    {
+      unsigned char flag;
+      mincore(va + i * page_size, 1, &flag);
+      // flag is 1 if the page was successfully allocated and in memory
+      if (!flag)
+        {
+          pm->error = clib_error_return_unix (0, "Unable to fulfill huge page allocation request");
+          goto error;
+        }
     }
 
   clib_memset (va, 0, size);


### PR DESCRIPTION
```
va = pm->base + (((uword) vec_len (pm->pages)) << pm->def_log2_page_sz);
  if (mmap (va, size, PROT_READ | PROT_WRITE, mmap_flags, a->fd, 0) ==
      MAP_FAILED)
    {
      pm->error = clib_error_return_unix (0, "failed to mmap %u pages at %p "
					  "fd %d numa %d flags 0x%x", n_pages,
					  va, a->fd, numa_node, mmap_flags);
      goto error;
    }

  clib_memset (va, 0, size);
```
mmap does not fail but writing to mapped memory is causing sigbus.
```
/usr/bin/vpp[17659]: received signal SIGBUS, PC 0x7fd2f01d58ba
/usr/bin/vpp[17659]: #0  0x00007fd2f0c6697d 0x7fd2f0c6697d
/usr/bin/vpp[17659]: #1  0x00007fd2f07bc890 0x7fd2f07bc890
/usr/bin/vpp[17659]: #2  0x00007fd2f01d58ba 0x7fd2f01d58ba
/usr/bin/vpp[17659]: #3  0x00007fd2f054d4f2 0x7fd2f054d4f2
/usr/bin/vpp[17659]: #4  0x00007fd2f054f673 clib_pmalloc_create_shared_arena + 0x213
/usr/bin/vpp[17659]: #5  0x00007fd2f0c46cf3 vlib_physmem_shared_map_create + 0x23
/usr/bin/vpp[17659]: #6  0x00007fd2f0c1b561 vlib_buffer_main_init + 0x151
/usr/bin/vpp[17659]: #7  0x00007fd2f0c3b70a vlib_main + 0x12a
/usr/bin/vpp[17659]: #8  0x00007fd2f0c65a56 0x7fd2f0c65a56
/usr/bin/vpp[17659]: #9  0x00007fd2f053bfc4 0x7fd2f053bfc4
```