### PR TITLE
dpdk: disable hqos

### DIFF
--- a/src/plugins/dpdk/device/init.c
+++ b/src/plugins/dpdk/device/init.c
@@ -771,6 +771,7 @@ dpdk_lib_init (dpdk_main_t * dm)
 		      format_dpdk_device_name, i,
 		      format_dpdk_device_errors, xd);
 
+#if 0
       if (devconf->hqos_enabled)
 	{
 	  clib_error_t *rv;
@@ -778,6 +779,7 @@ dpdk_lib_init (dpdk_main_t * dm)
 	  if (rv)
 	    return rv;
 	}
+#endif
 
       /*
        * A note on Cisco VIC (PMD_ENIC) and VLAN:


### PR DESCRIPTION
HQoS code is not fully disabled. Call to dpdk_port_setup_hqos is undefined.

Signed-off-by: Ruslan Babayev <ruslan@babayev.com>