### PR TITLE
Update memif_msg_receive_init API socket.c

### DIFF
--- a/extras/libmemif/src/socket.c
+++ b/extras/libmemif/src/socket.c
@@ -471,7 +471,7 @@ memif_msg_receive_init (memif_socket_t * ms, int fd, memif_msg_t * msg)
 
 error:
   memif_msg_send_disconnect (fd, err_string, 0);
-  lm->control_fd_update (fd, MEMIF_FD_EVENT_DEL, c->private_ctx);
+  lm->control_fd_update (fd, MEMIF_FD_EVENT_DEL, NULL/*c->private_ctx*/);
   free_list_elt (lm->pending_list, lm->pending_list_len, fd);
   close (fd);
   fd = -1;


### PR DESCRIPTION
If get_list_elt returns NULL element, then code jumps to error label. Here we are trying to access variable 'c' which is NULL. And 'c' would be set only if get_list_elt succeeds.
Also, since lm->control_fd_update() does not use private context, we could either pass NULL or remove the same.