### PR TITLE
Fix command binding for showing span configuration

### DIFF
--- a/src/vnet/span/span.c
+++ b/src/vnet/span/span.c
@@ -236,7 +236,7 @@ show_interfaces_span_command_fn (vlib_main_t * vm,
 
 /* *INDENT-OFF* */
 VLIB_CLI_COMMAND (show_interfaces_span_command, static) = {
-  .path = "show interface span",
+  .path = "show interfaces span",
   .short_help = "Shows SPAN mirror table",
   .function = show_interfaces_span_command_fn,
 };


### PR DESCRIPTION
Both documentation and function definition are showing that this command was supposed to be in the shape as fixed by this PR.

Signed-off-by: Piotr Skamruk <piotr.skamruk@gmail.com>