### PR TITLE
Fix crash when setting IPFIX collector

### DIFF
--- a/src/vnet/ipfix-export/flow_report.c
+++ b/src/vnet/ipfix-export/flow_report.c
@@ -839,12 +839,12 @@ set_ipfix_exporter_command_fn (vlib_main_t * vm,
 
   if (collector.ip.ip4.as_u32)
     vlib_cli_output (vm,
-		     "Collector %U, src address %U, "
+		     "Collector %U port %u, src address %U, "
 		     "fib index %d, path MTU %u, "
 		     "template resend interval %us, "
 		     "udp checksum %s",
-		     format_ip4_address, exp->ipfix_collector,
-		     format_ip4_address, exp->src_address, fib_index, path_mtu,
+		     format_ip4_address, &exp->ipfix_collector.ip.ip4.as_u32, exp->collector_port,
+		     format_ip4_address, &exp->src_address.ip.ip4.as_u32, fib_index, path_mtu,
 		     template_interval, udp_checksum ? "enabled" : "disabled");
   else
     vlib_cli_output (vm, "IPFIX Collector is disabled");


### PR DESCRIPTION
vlib_cli_output was crashing when calling format_ip4_address.
Passing the correct parameters fixes this.
Also, added the collector port to the output.