### PR TITLE
dpdk: fix program vlans on ixgbevf

### DIFF
--- a/src/plugins/dpdk/device/driver.c
+++ b/src/plugins/dpdk/device/driver.c
@@ -55,10 +55,15 @@ static dpdk_driver_t dpdk_drivers[] = {
     .int_unmaskable = 1,
   },
   {
-    .drivers = DPDK_DRIVERS ({ "net_e1000_igb_vf", "Intel e1000 VF" },
-			     { "net_ixgbe_vf", "Intel 82599 VF" }),
+    .drivers = DPDK_DRIVERS ({ "net_e1000_igb_vf", "Intel e1000 VF" }),
     .interface_name_prefix = "VirtualFunctionEthernet",
     .use_intel_phdr_cksum = 1,
+  },
+  {
+    .drivers = DPDK_DRIVERS ({ "net_ixgbe_vf", "Intel 82599 VF" }),
+    .interface_name_prefix = "VirtualFunctionEthernet",
+    .use_intel_phdr_cksum = 1,
+    .program_vlans = 1,
   },
   {
     .drivers = DPDK_DRIVERS ({ "net_dpaa2", "NXP DPAA2 Mac" }),


### PR DESCRIPTION
Type: fix

This commit https://github.com/FDio/vpp/commit/549838c81bd0d995f2b8569955afc33132582c77 have broken vlans programming on ixgbevf.


