### PR TITLE
fix compiler error in vapi_cpp_test.cpp

### DIFF
--- a/src/vpp-api/vapi/vapi_cpp_test.cpp
+++ b/src/vpp-api/vapi/vapi_cpp_test.cpp
@@ -15,6 +15,7 @@
  *------------------------------------------------------------------
  */
 
+#include <array>
 #include <memory>
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
Missing include <array> cause a compiler error:
src/vpp-api/vapi/vapi_cpp_test.cpp:280:43: error: implicit instantiation of undefined template 'std::array<Create_loopback_cb, 5>