### PR TITLE
fix when show event-logger about api-msg，the  control_ping is thread

### DIFF
--- a/src/vlibapi/api_shared.c
+++ b/src/vlibapi/api_shared.c
@@ -604,8 +604,8 @@ msg_handler_internal (api_main_t *am, void *the_msg, uword msg_len,
           .n_enum_strings = 2,
           .enum_strings =
           {
-            "barrier",
             "mp-safe",
+            "barrier",
           }
         };
       /* *INDENT-ON* */


### PR DESCRIPTION
… 1, ed->barrier is 0, so enum_strings[0] must be "mp-safe".

auth:xiaolizi
date:Tue 23 Aug 2022 16:36:55 PM CST
src/vlibapi/api_shared.c