### PR TITLE
vnet: fix classify_pcap_set_table api

### DIFF
--- a/src/vnet/classify/classify_api.c
+++ b/src/vnet/classify/classify_api.c
@@ -116,7 +116,7 @@ static void vl_api_classify_pcap_set_table_t_handler
   u32 sw_if_index = ntohl (mp->sw_if_index);
 
   if (sw_if_index == ~0
-      || sw_if_index >= vec_len (cm->classify_table_index_by_sw_if_index)
+      || (sw_if_index > 0 && sw_if_index >= vec_len (cm->classify_table_index_by_sw_if_index))
       || (table_index != ~0 && pool_is_free_index (cm->tables, table_index)))
     {
       rv = VNET_API_ERROR_INVALID_VALUE;


### PR DESCRIPTION
When calling the classify_pcap_set_table api, a check is present to ensure that the provided sw_if_index is less than the number of entries in the lookup table used to map the sw_if_index to a table_id. If the check fails, the API call fails with an VNET_API_ERROR_INVALID_VALUE.

This poses a problem, as the lookup table is initialized in classify_set_pcap_chain, which is called after this initial check is made. Since lookup table is never initialized, the API call will always fail.

When adding a pcap filter via the CLI, sw_if_index is always set to zero, and there the call to classify_set_pcap_chain is made without the above check.

This change provides a fix to allow the call to the classify_pcap_set_table to bypass the lookup table length test if the sw_if_index is set for all interfaces (i.e. set to 0), mimicking the CLI behavior.

Type: fix