### PR TITLE
Attempt to use a syslog socket, falling back to standard output.

### DIFF
--- a/extras/vpp_stats_fs/cmd.go
+++ b/extras/vpp_stats_fs/cmd.go
@@ -44,11 +44,13 @@ func LogMsg(msg string) {
 }
 
 func main() {
-	syslogger, err := syslog.New(syslog.LOG_ERR|syslog.LOG_DAEMON, "statsfs")
-	if err != nil {
-		log.Fatalln(err)
+	syslogger, err := syslog.New(syslog.LOG_ERR | syslog.LOG_DAEMON, "statsfs")
+
+	if err == nil {
+	        log.SetOutput(syslogger)
+	} else {
+		log.SetOutput(os.Stdout)
 	}
-	log.SetOutput(syslogger)
 
 	statsSocket := flag.String("socket", statsclient.DefaultSocketName, "Path to VPP stats socket")
 	debug := flag.Bool("debug", false, "print debugging messages.")


### PR DESCRIPTION
Use standard output if a syslog socket is unavailable.

This is so that we can run the stats_fs filesystem within a Docker container.