### PR TITLE
Change DPDK version related to RTE_MEMPOOL_F_NON_IO flag.

### DIFF
--- a/src/plugins/dpdk/buffer.c
+++ b/src/plugins/dpdk/buffer.c
@@ -116,7 +116,7 @@ dpdk_buffer_pool_init (vlib_main_t * vm, vlib_buffer_pool_t * bp)
       mp->populated_size++;
       nmp->populated_size++;
     }
-#if RTE_VERSION >= RTE_VERSION_NUM(22, 3, 0, 0)
+#if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
   mp->flags &= ~RTE_MEMPOOL_F_NON_IO;
 #endif
 


### PR DESCRIPTION
RTE_MEMPOOL_F_NON_IO is added from DPDK 21.11.0