### PR TITLE
vlib: fix fake stack size set error when switching to process, replac…

### DIFF
--- a/src/vlib/node_funcs.h
+++ b/src/vlib/node_funcs.h
@@ -60,7 +60,7 @@ vlib_process_start_switch_stack (vlib_main_t * vm, vlib_process_t * p)
 #ifdef CLIB_SANITIZE_ADDR
   void *stack = p ? (void *) p->stack : vlib_thread_stacks[vm->thread_index];
   u32 stack_bytes =
-    p ? (1ULL < p->log2_n_stack_bytes) : VLIB_THREAD_STACK_SIZE;
+    p ? (1ULL << p->log2_n_stack_bytes) : VLIB_THREAD_STACK_SIZE;
   __sanitizer_start_switch_fiber (&vm->asan_stack_save, stack, stack_bytes);
 #endif
 }


### PR DESCRIPTION
vlib: fix fake stack size set error when switching to process, replace '1<n' with '1<<n'

Type: fix