### PR TITLE
Update Makefile to automatically accept Apt changes for headless use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ bootstrap:
 install-dep:
 ifeq ($(filter ubuntu debian linuxmint,$(OS_ID)),$(OS_ID))
 	@sudo -E apt-get update
-	@sudo -E apt-get $(APT_ARGS) $(CONFIRM) $(FORCE) install $(DEB_DEPENDS)
+	@sudo -E apt-get $(APT_ARGS) $(CONFIRM) $(FORCE) install $(DEB_DEPENDS) -y
 else ifneq ("$(wildcard /etc/redhat-release)","")
 ifeq ($(OS_ID),rhel)
 	@sudo -E yum-config-manager --enable rhel-server-rhscl-7-rpms


### PR DESCRIPTION
Updated Makefile for Debian / Ubuntu systems to add the `-y` flag to the `apt-get install` so the user is not prompted to allow use from headless systems.