### PR TITLE
Update ip6_forward.c

### DIFF
--- a/src/vnet/ip/ip6_forward.c
+++ b/src/vnet/ip/ip6_forward.c
@@ -2455,7 +2455,7 @@ ip6_scan_hbh_options (vlib_buffer_t * b0,
 		    }
 		  break;
 		}
-	      return (error0);
+	      //return (error0);
 	    }
 	}
       opt0 =


### PR DESCRIPTION
according to RFC2460, all sub options under HBH should be processed one by one, NOT only the first one processed.