### PR TITLE
fix scoreboard build and  SIGSEVG

### DIFF
--- a/src/vnet/tcp/tcp_cli.c
+++ b/src/vnet/tcp/tcp_cli.c
@@ -650,7 +650,7 @@ tcp_scoreboard_dump_trace (u8 * s, sack_scoreboard_t * sb)
   vec_foreach (block, sb->trace)
   {
     s = format (s, "{%u, %u, %u, %u, %u}, ", block->start, block->end,
-		block->ack, block->snd_una_max, block->group);
+		block->ack, block->snd_nxt, block->group);
     if ((++i % 3) == 0)
       s = format (s, "\n");
   }
@@ -684,6 +684,8 @@ tcp_show_scoreboard_trace_fn (vlib_main_t * vm, unformat_input_t * input,
     }
 
   tc = tcp_get_connection_from_transport (tconn);
+  if (!tc)
+  	return 0;
   s = tcp_scoreboard_dump_trace (s, &tc->sack_sb);
   vlib_cli_output (vm, "%v", s);
   return 0;

--- a/src/vnet/tcp/tcp_sack.h
+++ b/src/vnet/tcp/tcp_sack.h
@@ -88,7 +88,7 @@ scoreboard_last_hole (sack_scoreboard_t * sb)
 	_elt->start = _sack->start;					\
 	_elt->end = _sack->end;						\
 	_elt->ack = _elt->end == _ack ? _ack : 0;			\
-	_elt->snd_una_max = _elt->end == _ack ? _tc->snd_una_max : 0;	\
+	_elt->snd_nxt = _elt->end == _ack ? _tc->snd_nxt : 0;	\
 	_elt->group = _group;						\
       }									\
 }


### PR DESCRIPTION
start trace debug macro and will coredump, when executes `show tcp scoreboard trace` command .