### PR TITLE
Enable support for Solarflare 7042Q NIC

### DIFF
--- a/build/external/packages/dpdk.mk
+++ b/build/external/packages/dpdk.mk
@@ -80,7 +80,6 @@ DPDK_DRIVERS_DISABLED := baseband/\*,	\
 	net/liquidio,						\
 	net/pcap,							\
 	net/pfe,							\
-	net/sfc,							\
 	net/softnic,						\
 	net/thunderx,						\
 	raw/ifpga,							\

--- a/src/plugins/dpdk/device/driver.c
+++ b/src/plugins/dpdk/device/driver.c
@@ -129,6 +129,10 @@ static dpdk_driver_t dpdk_drivers[] = {
   {
     .drivers = DPDK_DRIVERS ({ "net_gve", "Google vNIC" }),
     .interface_name_prefix = "VirtualFunctionEthernet",
+  },
+  {
+    .drivers = DPDK_DRIVERS ({ "net_sfc_efx", "Solarflare SFN7042Q" }),
+    .interface_name_prefix = "FortyGigabitEthernet",
   }
 };
 

--- a/src/plugins/dpdk/device/init.c
+++ b/src/plugins/dpdk/device/init.c
@@ -796,6 +796,10 @@ dpdk_bind_devices_to_uio (dpdk_config_main_t * conf)
     /* Google vNIC */
     else if (d->vendor_id == 0x1ae0 && d->device_id == 0x0042)
       ;
+    /* Solarflare SFN7042Q */
+    else if (d->vendor_id == 0x1924 &&
+             (d->device_id == 0x0923 || d->device_id == 0x1923))
+      ;
     else
       {
         dpdk_log_warn ("Unsupported PCI device 0x%04x:0x%04x found "


### PR DESCRIPTION
Enabled building net_sfc driver in dpdk.mk
Added SFN7042Q adapter and virtual functions to init.c and driver.c
