### PR TITLE
Update kernel_vpp_ipsec.c

### DIFF
--- a/extras/strongswan/vpp_sswan/kernel_vpp_ipsec.c
+++ b/extras/strongswan/vpp_sswan/kernel_vpp_ipsec.c
@@ -1795,7 +1795,8 @@ METHOD (kernel_ipsec_t, del_sa, status_t, private_kernel_vpp_ipsec_t *this,
     {
       DBG1 (DBG_KNL, "SA not found");
       rv = NOT_FOUND;
-      goto error;
+      this->mutex->unlock (this->mutex);
+      return rv;
     }
   mp = vl_msg_api_alloc (sizeof (*mp));
   memset (mp, 0, sizeof (*mp));


### PR DESCRIPTION
There was an issue in del_sa function where if there is no SA found due to any reason then it would fall into error label where it would try to free mp memory which get allocated later down in this function.