### PR TITLE
DET44: IPFIX support for DET44.

### DIFF
--- a/src/plugins/nat/det44/det44.c
+++ b/src/plugins/nat/det44/det44.c
@@ -332,7 +332,7 @@ det44_expire_walk_fn (vlib_main_t * vm, vlib_node_runtime_t * rt,
 	      // close expired sessions
 	      if (ses->in_port && (ses->expire < now))
 		{
-		  snat_det_ses_close (mp, ses);
+		  snat_det_ses_close (vm->thread_index, mp, ses);
 		}
 	    }
 	}

--- a/src/plugins/nat/det44/det44_api.c
+++ b/src/plugins/nat/det44/det44_api.c
@@ -170,7 +170,7 @@ vl_api_det44_close_session_out_t_handler (vl_api_det44_close_session_out_t
       rv = VNET_API_ERROR_NO_SUCH_ENTRY;
       goto send_reply;
     }
-  snat_det_ses_close (m, ses);
+  snat_det_ses_close (dm->vnet_main->vlib_main->thread_index, m, ses);
 
 send_reply:
   REPLY_MACRO (VL_API_DET44_CLOSE_SESSION_OUT_REPLY);
@@ -204,7 +204,7 @@ vl_api_det44_close_session_in_t_handler (vl_api_det44_close_session_in_t * mp)
       rv = VNET_API_ERROR_NO_SUCH_ENTRY;
       goto send_reply;
     }
-  snat_det_ses_close (m, ses);
+  snat_det_ses_close (dm->vnet_main->vlib_main->thread_index, m, ses);
 
 send_reply:
   REPLY_MACRO (VL_API_DET44_CLOSE_SESSION_OUT_REPLY);
@@ -505,7 +505,7 @@ vl_api_nat_det_close_session_out_t_handler (vl_api_nat_det_close_session_out_t
       rv = VNET_API_ERROR_NO_SUCH_ENTRY;
       goto send_reply;
     }
-  snat_det_ses_close (m, ses);
+  snat_det_ses_close (dm->vnet_main->vlib_main->thread_index, m, ses);
 
 send_reply:
   REPLY_MACRO (VL_API_NAT_DET_CLOSE_SESSION_OUT_REPLY);
@@ -540,7 +540,7 @@ vl_api_nat_det_close_session_in_t_handler (vl_api_nat_det_close_session_in_t *
       rv = VNET_API_ERROR_NO_SUCH_ENTRY;
       goto send_reply;
     }
-  snat_det_ses_close (m, ses);
+  snat_det_ses_close (dm->vnet_main->vlib_main->thread_index, m, ses);
 
 send_reply:
   REPLY_MACRO (VL_API_NAT_DET_CLOSE_SESSION_OUT_REPLY);

--- a/src/plugins/nat/det44/det44_cli.c
+++ b/src/plugins/nat/det44/det44_cli.c
@@ -245,7 +245,7 @@ det44_close_session_out_fn (vlib_main_t * vm,
       if (!ses)
 	vlib_cli_output (vm, "no match");
       else
-	snat_det_ses_close (mp, ses);
+	snat_det_ses_close (vm->thread_index, mp, ses);
     }
 
 done:
@@ -297,7 +297,7 @@ det44_close_session_in_fn (vlib_main_t * vm,
       if (!ses)
 	vlib_cli_output (vm, "no match");
       else
-	snat_det_ses_close (mp, ses);
+	snat_det_ses_close (vm->thread_index, mp, ses);
     }
 
 done:

--- a/src/plugins/nat/det44/det44_in2out.c
+++ b/src/plugins/nat/det44/det44_in2out.c
@@ -217,6 +217,10 @@ icmp_match_in2out_det (vlib_node_runtime_t * node,
 	  b0->error = node->errors[DET44_IN2OUT_ERROR_OUT_OF_PORTS];
 	  goto out;
 	}
+	nat_ipfix_logging_nat44_ses_create (
+	  thread_index, in_addr.as_u32, new_addr0.as_u32, 1,
+	  echo0->identifier, key0.out_port, dm->outside_fib_index);
+
     }
 
   if (PREDICT_FALSE
@@ -536,6 +540,9 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	      next0 = DET44_IN2OUT_NEXT_ICMP_ERROR;
 	      goto trace0;
 	    }
+		nat_ipfix_logging_nat44_ses_create (
+		  thread_index, ip0->src_address.as_u32, new_addr0.as_u32, ip0->protocol,
+		  tcp0->src_port, key0.out_port, dm->outside_fib_index);
 	}
 
       old_port0 = udp0->src_port;
@@ -562,7 +569,7 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	    ses0->state = DET44_SESSION_TCP_FIN_WAIT;
 	  else if (tcp0->flags & TCP_FLAG_ACK
 		   && ses0->state == DET44_SESSION_TCP_FIN_WAIT)
-	    snat_det_ses_close (mp0, ses0);
+	    snat_det_ses_close (thread_index, mp0, ses0);
 	  else if (tcp0->flags & TCP_FLAG_FIN
 		   && ses0->state == DET44_SESSION_TCP_CLOSE_WAIT)
 	    ses0->state = DET44_SESSION_TCP_LAST_ACK;
@@ -706,6 +713,9 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	      next1 = DET44_IN2OUT_NEXT_ICMP_ERROR;
 	      goto trace1;
 	    }
+		nat_ipfix_logging_nat44_ses_create (
+		  thread_index, ip1->src_address.as_u32, new_addr1.as_u32, ip1->protocol,
+		  tcp1->src, key1.out_port, dm->outside_fib_index);
 	}
 
       old_port1 = udp1->src_port;
@@ -732,7 +742,7 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	    ses1->state = DET44_SESSION_TCP_FIN_WAIT;
 	  else if (tcp1->flags & TCP_FLAG_ACK
 		   && ses1->state == DET44_SESSION_TCP_FIN_WAIT)
-	    snat_det_ses_close (mp1, ses1);
+	    snat_det_ses_close (thread_index, mp1, ses1);
 	  else if (tcp1->flags & TCP_FLAG_FIN
 		   && ses1->state == DET44_SESSION_TCP_CLOSE_WAIT)
 	    ses1->state = DET44_SESSION_TCP_LAST_ACK;
@@ -904,6 +914,9 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	      next0 = DET44_IN2OUT_NEXT_ICMP_ERROR;
 	      goto trace00;
 	    }
+		nat_ipfix_logging_nat44_ses_create (
+		  thread_index, ip0->src_address.as_u32, new_addr0.as_u32, ip0->protocol,
+		  tcp0->src, key0.out_port, dm->outside_fib_index);
 	}
 
       old_port0 = udp0->src_port;
@@ -930,7 +943,7 @@ VLIB_NODE_FN (det44_in2out_node) (vlib_main_t * vm,
 	    ses0->state = DET44_SESSION_TCP_FIN_WAIT;
 	  else if (tcp0->flags & TCP_FLAG_ACK
 		   && ses0->state == DET44_SESSION_TCP_FIN_WAIT)
-	    snat_det_ses_close (mp0, ses0);
+	    snat_det_ses_close (thread_index, mp0, ses0);
 	  else if (tcp0->flags & TCP_FLAG_FIN
 		   && ses0->state == DET44_SESSION_TCP_CLOSE_WAIT)
 	    ses0->state = DET44_SESSION_TCP_LAST_ACK;

--- a/src/plugins/nat/det44/det44_out2in.c
+++ b/src/plugins/nat/det44/det44_out2in.c
@@ -502,7 +502,7 @@ VLIB_NODE_FN (det44_out2in_node) (vlib_main_t * vm,
 	    ses0->state = DET44_SESSION_TCP_CLOSE_WAIT;
 	  else if (tcp0->flags & TCP_FLAG_ACK
 		   && ses0->state == DET44_SESSION_TCP_LAST_ACK)
-	    snat_det_ses_close (mp0, ses0);
+	    snat_det_ses_close (thread_index, mp0, ses0);
 
 	  sum0 = tcp0->checksum;
 	  sum0 = ip_csum_update (sum0, old_addr0.as_u32, new_addr0.as_u32,
@@ -620,7 +620,7 @@ VLIB_NODE_FN (det44_out2in_node) (vlib_main_t * vm,
 	    ses1->state = DET44_SESSION_TCP_CLOSE_WAIT;
 	  else if (tcp1->flags & TCP_FLAG_ACK
 		   && ses1->state == DET44_SESSION_TCP_LAST_ACK)
-	    snat_det_ses_close (mp1, ses1);
+	    snat_det_ses_close (thread_index, mp1, ses1);
 
 	  sum1 = tcp1->checksum;
 	  sum1 = ip_csum_update (sum1, old_addr1.as_u32, new_addr1.as_u32,
@@ -765,7 +765,7 @@ VLIB_NODE_FN (det44_out2in_node) (vlib_main_t * vm,
 	    ses0->state = DET44_SESSION_TCP_CLOSE_WAIT;
 	  else if (tcp0->flags & TCP_FLAG_ACK
 		   && ses0->state == DET44_SESSION_TCP_LAST_ACK)
-	    snat_det_ses_close (mp0, ses0);
+	    snat_det_ses_close (thread_index, mp0, ses0);
 
 	  sum0 = tcp0->checksum;
 	  sum0 = ip_csum_update (sum0, old_addr0.as_u32, new_addr0.as_u32,


### PR DESCRIPTION
Added IPFIX nat event messages to DET44.

Configure DET44 - two interfaces are required:
```
det44 plugin enable
set interface det44 outside tap0
set interface det44 inside tap1
det44 add in 10.0.0.0/24 out 192.168.33.2/31
```
Enable the IPFIX logging:
```
set ipfix exporter collector 192.168.33.1 port 7788 src 192.168.33.2  template-interval 20
nat ipfix logging enable
```

Check collector's output:
```
observationTimeMilliseconds 1758891217327(2025-09-26 14:53:37 +0200) natEvent 4(created) sourceIPv4Address 10.0.0.11 postNATSourceIPv4Address 192.168.33.2 protocolIdentifier 6(TCP) sourceTransportPort 42202 postNAPTSourceTransportPort 6938 ingressVRFID 0 
observationTimeMilliseconds 1758891277399(2025-09-26 14:54:37 +0200) natEvent 5(deleted) sourceIPv4Address 10.0.0.11 postNATSourceIPv4Address 192.168.33.2 protocolIdentifier 6(TCP) sourceTransportPort 42202 postNAPTSourceTransportPort 6938 ingressVRFID 0
```
